### PR TITLE
Obscure sensible values on .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Set it to 0 when running on production. See the README for further explanation
+DISPLAY_ERRORS=0
+
 TWILIO_ACCOUNT_SID=ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 TWILIO_CALLER_ID=+1XXXYYYZZZZ
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ After the above requirements have been met:
     cp .env.example .env
     ```
 
+    On production, to avoid showing errors, you should set the variable `DISPLAY_ERRORS` to
+   `0`. For development, it can be set to `1` on development. For more information, read
+   [this](https://phpdelusions.net/articles/error_reporting)
+
     See [Twilio Account Settings](#twilio-account-settings) to locate the necessary environment variables.
 
 1. Run the application

--- a/token.php
+++ b/token.php
@@ -8,18 +8,21 @@ use Twilio\Jwt\Grants\VoiceGrant;
 $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
 $dotenv->load();
 
+$DISPLAY_ERRORS = $_ENV['DISPLAY_ERRORS'];
+ini_set('display_errors', $DISPLAY_ERRORS);
+
 function get_access_token($identity) {
     $access_token = new AccessToken(
-        getenv('TWILIO_ACCOUNT_SID'),
-        getenv('API_KEY'),
-        getenv('API_SECRET'),
+        $_ENV['TWILIO_ACCOUNT_SID'],
+        $_ENV['API_KEY'],
+        $_ENV['API_SECRET'],
         3600,
         $identity
     );
     
     // Create Voice grant
     $voiceGrant = new VoiceGrant();
-    $voiceGrant->setOutgoingApplicationSid(getenv('TWILIO_TWIML_APP_SID'));
+    $voiceGrant->setOutgoingApplicationSid($_ENV['TWILIO_TWIML_APP_SID']);
     
     // Optional: add to allow incoming calls
     $voiceGrant->setIncomingAllow(true);

--- a/voice.php
+++ b/voice.php
@@ -6,12 +6,15 @@ use Twilio\TwiML\VoiceResponse;
 $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
 $dotenv->load();
 
+$DISPLAY_ERRORS = $_ENV['DISPLAY_ERRORS'];
+ini_set('display_errors', $DISPLAY_ERRORS);
+
 function get_voice_response($to) {
     $response = new VoiceResponse();
 
     if (!empty($to) && strlen($to) > 0) {
         $number = htmlspecialchars($to);
-        $dial = $response->dial('', ['callerId' => getenv('TWILIO_CALLER_ID')]);
+        $dial = $response->dial('', ['callerId' => $_ENV['TWILIO_CALLER_ID']]);
         
         // wrap the phone number or client name in the appropriate TwiML verb
         // by checking if the number given has only digits and format symbols


### PR DESCRIPTION
Avoids exposing sensible variables on production.

Changes in the PR:

- Change `DISPLAY_ERRORS` to `false`.
- Set `display_errors` to `0` on production
- Update README.